### PR TITLE
Extend ingress to support conditional lambda on class

### DIFF
--- a/lib/ingress/permission_rule.rb
+++ b/lib/ingress/permission_rule.rb
@@ -16,7 +16,6 @@ module Ingress
     def match?(given_action, given_subject, user, options = {})
       return false unless action_matches?(given_action)
       return false unless subject_matches?(given_subject)
-      return true if ignore_conditions?(given_subject)
 
       conditions_match?(user, given_subject, options)
     end
@@ -34,14 +33,6 @@ module Ingress
         given_subject.class == subject ||
         given_subject == "*" ||
         "*" == subject
-    end
-
-    def ignore_conditions?(given_subject)
-      subject_class?(given_subject) && subject_class?(@subject)
-    end
-
-    def subject_class?(subject)
-      [Class, Module].include? subject.class
     end
 
     def conditions_match?(user, given_subject, options)

--- a/lib/ingress/permission_rule.rb
+++ b/lib/ingress/permission_rule.rb
@@ -6,7 +6,7 @@ module Ingress
       @allows = allows
       @action = action
       @subject = subject
-      @conditions = [conditions].compact.flatten
+      @conditions = conditions
     end
 
     def allows?

--- a/lib/ingress/version.rb
+++ b/lib/ingress/version.rb
@@ -1,3 +1,3 @@
 module Ingress
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/ingress_spec.rb
+++ b/spec/ingress_spec.rb
@@ -387,7 +387,9 @@ RSpec.describe Ingress do
         define_role_permissions do
           can "*", :wodget
 
-          can "*", TestObject, if: -> (user, record) { record.kind_of?(TestObject) && record.id == 5 }
+          can "*", TestObject, if: -> (user, record) do
+            record.is_a?(Class) ? true : (record.kind_of?(TestObject) && record.id == 5)
+          end
 
           can "*", :with_if_style, if: -> (user, record) { record.kind_of?(TestObject) && record.id == 5 }
           can "*", :with_block do |user, record|
@@ -437,7 +439,7 @@ RSpec.describe Ingress do
       end
 
       it "should be able to do action if Class is provided" do
-        expect(permissions.can?(:with_block, TestObject)).to be_truthy
+        expect(permissions.can?(:foo, TestObject)).to be_truthy
       end
     end
 

--- a/spec/ingress_spec.rb
+++ b/spec/ingress_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Ingress do
           can :create, TestObject
           can :destroy, TestObject
 
-          can :update, TestObject, if: -> (user, object) { user.id == object.user_id }
-          cannot %i[update destroy], TestObject, if: -> (user, object) { object.read_only }
+          can :update, TestObject, if: -> (user, object) { user.id == object.user_id unless object.is_a?(Class) }
+          cannot %i[update destroy], TestObject, if: -> (user, object) { object.read_only unless object.is_a?(Class)}
           cannot '*', '*', if: -> (user, _object) { user.disabled }
         end
       end
@@ -391,8 +391,8 @@ RSpec.describe Ingress do
             record.is_a?(Class) ? true : (record.kind_of?(TestObject) && record.id == 5)
           end
 
-          can "*", :with_if_style, if: -> (user, record) { record.kind_of?(TestObject) && record.id == 5 }
-          can "*", :with_block do |user, record|
+          can "*", :with_if_style, if: -> (_user, _action, record) { record.kind_of?(TestObject) && record.id == 5 }
+          can "*", :with_block do |_user, _action, record|
             record.kind_of?(TestObject) && record.id == 5
           end
         end
@@ -445,19 +445,19 @@ RSpec.describe Ingress do
 
     context "differing styles of defining conditions" do
       it "permits when defined with an if: condition" do
-        expect(permissions.can?(:with_if_style, TestObject.new(id: 5))).to be_truthy
+        expect(permissions.can?(:foo, :with_if_style, TestObject.new(id: 5))).to be_truthy
       end
 
       it "permits when defined with a block condition" do
-        expect(permissions.can?(:with_block, TestObject.new(id: 5))).to be_truthy
+        expect(permissions.can?(:foo, :with_block, TestObject.new(id: 5))).to be_truthy
       end
 
       it "denies when defined with an if: condition" do
-        expect(permissions.can?(:with_if_style, TestObject.new(id: 4))).to be_falsy
+        expect(permissions.can?(:foo, :with_if_style, TestObject.new(id: 4))).to be_falsy
       end
 
       it "denies when defined with a block condition" do
-        expect(permissions.can?(:with_block, TestObject.new(id: 4))).to be_falsy
+        expect(permissions.can?(:foo, :with_block, TestObject.new(id: 4))).to be_falsy
       end
     end
   end

--- a/spec/ingress_spec.rb
+++ b/spec/ingress_spec.rb
@@ -387,9 +387,28 @@ RSpec.describe Ingress do
         define_role_permissions do
           can "*", :wodget
 
-          can "*", TestObject, if: -> (user, record) do
-            record.is_a?(Class) ? true : (record.kind_of?(TestObject) && record.id == 5)
+          can :foo, TestObject, if: -> (user, given_subject) do
+            given_subject.kind_of?(TestObject) ? (given_subject.id == 5) : true
           end
+
+          can :bar, TestObject, if_subject_is_an_instance: -> (user, object, option) do
+            object.id == 5
+          end
+
+          can :baz, TestObject, if_subject_is_a_class: -> (user, klass, option) do
+            option[:id] == 9
+          end
+
+          can :foo_bar_baz, TestObject,
+            if: -> (user, given_subject) do
+              given_subject.kind_of?(TestObject) ? (given_subject.id == 5) : true
+            end,
+            if_subject_is_an_instance: -> (user, object, option) do
+              option[:id] == 5
+            end,
+            if_subject_is_a_class: -> (user, klass, option) do
+              option[:id] == 9
+            end
 
           can "*", :with_if_style, if: -> (_user, _action, record) { record.kind_of?(TestObject) && record.id == 5 }
           can "*", :with_block do |_user, _action, record|
@@ -428,10 +447,9 @@ RSpec.describe Ingress do
       expect(permissions.can?(:foo, :bazzer)).to be_falsy
     end
 
-    context "with a condition" do
+    context "with the 'if:' condition" do
       it "user is able to do any action on a thing where the condition is met" do
         expect(permissions.can?(:foo, TestObject.new(id: 5))).to be_truthy
-        expect(permissions.can?(:bar, TestObject.new(id: 5))).to be_truthy
       end
 
       it "user is not able to do any action on a thing where the condition is not met" do
@@ -440,6 +458,61 @@ RSpec.describe Ingress do
 
       it "should be able to do action if Class is provided" do
         expect(permissions.can?(:foo, TestObject)).to be_truthy
+      end
+    end
+
+    context "with the 'if_subject_is_an_instance:' condition" do
+      it "user is able to do any action on a thing where the condition is met" do
+        expect(permissions.can?(:bar, TestObject.new(id: 5))).to be_truthy
+      end
+
+      it "user is not able to do any action on a thing where the condition is not met" do
+        expect(permissions.can?(:bar, TestObject.new(id: 4))).to be_falsy
+      end
+
+      it "user is able to do any action if Class is provided" do
+        expect(permissions.can?(:bar, TestObject)).to be_truthy
+      end
+    end
+
+    context "with the 'if_subject_is_a_class:' condition" do
+      it "user is able to do any action on a thing where the condition is met" do
+        expect(permissions.can?(:baz, TestObject, { id: 9 })).to be_truthy
+      end
+
+      it "user is not able to do any action on a thing where the condition is not met" do
+        expect(permissions.can?(:baz, TestObject, { id: 4 })).to be_falsy
+      end
+
+      it "user is able to do any action if an instance is provided" do
+        expect(permissions.can?(:baz, TestObject.new(id: 9))).to be_truthy
+      end
+    end
+
+    context "with the all the conditions combined" do
+      context "when all the conditions are not met" do
+        it "user is able to do any action on a thing where the condition is met" do
+          expect(permissions.can?(:foo_bar_baz, TestObject.new(id: 5), { id: 5 })).to be_truthy
+          expect(permissions.can?(:foo_bar_baz, TestObject, { id: 9 })).to be_truthy
+        end
+      end
+
+      context "when the 'if:' condition is not met" do
+        it "user is able not to do any action on a thing" do
+          expect(permissions.can?(:foo_bar_baz, TestObject.new(id: 9), { id: 5 })).to be_falsy
+        end
+      end
+
+      context "when the 'if_subject_is_an_instance:' condition is not met" do
+        it "user is able not to do any action on a thing" do
+          expect(permissions.can?(:foo_bar_baz, TestObject.new(id: 5), { id: 9 })).to be_falsy
+        end
+      end
+
+      context "when the 'if_subject_is_a_class:' condition is not met" do
+        it "user is able not to do any action on a thing" do
+          expect(permissions.can?(:foo_bar_baz, TestObject, { id: 10 })).to be_falsy
+        end
       end
     end
 


### PR DESCRIPTION
# Context

Currently, there's a skip condition that checks if the given subject is
a class. This introduces unnecessary concern to the ingress library on
handling the subject. As a result, this introduces an undesired behavior
where when a user passes a Class as a given subject, it will always return
true unknowingly that the conditional lambda is never evaluated.

This PR refactors the code to make Ingress more generic and simple.
The `if:` condition will evaluate the lambda regardless if it's a Class
or an Object. The user is responsible for defining the lambda correctly
and handle the subject accordingly.

To make the interface easy, on this PR, we introduce 2
conditional lambdas:
* `if_subject_is_a_class`
* `if_subject_is_an_instance`

These conditional lambdas provide a convenient interface to evaluate
conditional lambda when the given subject is a Class or an Instance.

# Changes

* Remove Skip Condition when subject is a Class
* Fixes some incorrect specs
* Introduces 2 conditional lambdas for convenience to handle given_subject:
  * `if_subject_is_a_class`
  * `if_subject_is_an_instance`
